### PR TITLE
Refactored loader.js

### DIFF
--- a/scripts/furaffinity.net/loader.js
+++ b/scripts/furaffinity.net/loader.js
@@ -8,24 +8,24 @@ let styleHolder;
 let scriptHolder;
 
 // Queue plugins
-function queuePlugin(namespace, type) {
-  console.log(`Queued ${namespace}`);
+function queuePlugins(plugins) {
+  plugins.forEach(([namespace, type]) => {
+    console.debug(`Queued ${namespace}`);
 
-  if (type & SCRIPT) {
-    console.log("Has script");
-    const scriptUrl = browser.runtime.getURL(`web-accessible/furaffinity.net/plugins/${namespace}/index.js`);
-    queuedScripts.push(scriptUrl);
-  }
+    if (type & SCRIPT) {
+      const scriptUrl = browser.runtime.getURL(`web-accessible/furaffinity.net/plugins/${namespace}/index.js`);
+      queuedScripts.push(scriptUrl);
+    }
 
-  if (type & STYLE) {
-    console.log("Has style");
-    const styleUrl = browser.runtime.getURL(`web-accessible/furaffinity.net/plugins/${namespace}/style.css`);
-    queuedStylesheets.push(styleUrl);
-  }
+    if (type & STYLE) {
+      const styleUrl = browser.runtime.getURL(`web-accessible/furaffinity.net/plugins/${namespace}/style.css`);
+      queuedStylesheets.push(styleUrl);
+    }
+  });
 }
 
 // Plugin declarations
-[
+queuePlugins([
   ["mergeMobileBars", STYLE],
   ["mobileFixMessagesButtons", STYLE],
   ["noBBCodeColor", STYLE],
@@ -37,15 +37,17 @@ function queuePlugin(namespace, type) {
   ["removeTopbarTransactions", STYLE],
 
   ["modules", SCRIPT],
+
   ["tabStatus", SCRIPT],
   ["liveStatus", SCRIPT],
+
   ["unwatchDATM", SCRIPT],
   ["systemMessageOverlay", SCRIPT],
-  ["nukeAllMessages", SCRIPT],
 
+  ["nukeAllMessages", SCRIPT],
   ["noGalleryPreview", STYLE | SCRIPT],
   ["showMeTheTags", STYLE | SCRIPT]
-].forEach(([name, type]) => queuePlugin(name, type));
+]);
 
 // Style injection
 function createStyleHolder(root) {
@@ -55,42 +57,12 @@ function createStyleHolder(root) {
   return container;
 }
 
-//**
-// function injectStyle(src, parent = document.head) {
-//   const link = document.createElement("link");
-//   link.href = src;
-//   link.rel = "preload stylesheet"; // Note: this is invalid, updated function below
-//   link.setAttribute("blocking", "render");
-//   parent.appendChild(link);
-// }
-//*/
-
 function injectStyle(src, parent = document.head) {
-  const supportsPreload = document.createElement("link").relList.supports?.("preload");
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = src;
 
-  if (supportsPreload) {
-    const link = document.createElement("link");
-    link.rel = "preload";
-    link.href = src;
-    link.as = "style";
-    link.setAttribute("blocking", "render");
-
-    const swapRel = () => {
-      link.rel = "stylesheet";
-      link.removeAttribute("as");
-    };
-
-    link.onload = swapRel;
-    link.onerror = swapRel;
-
-    parent.appendChild(link);
-  } else {
-    const fallback = document.createElement("link");
-    fallback.rel = "stylesheet";
-    fallback.href = src;
-    fallback.setAttribute("blocking", "render");
-    parent.appendChild(fallback);
-  }
+  parent.appendChild(link);
 }
 
 async function onHeadLoaded() {

--- a/scripts/furaffinity.net/loader.js
+++ b/scripts/furaffinity.net/loader.js
@@ -1,79 +1,113 @@
+const STYLE = 0b01;
+const SCRIPT = 0b10;
+
+const queuedStylesheets = [];
+const queuedScripts = [];
+
 let styleHolder;
 let scriptHolder;
 
-let queuedStylesheets = [];
-let queuedScripts = [];
-
-// Plugin functions
-
+// Queue plugins
 function queuePlugin(namespace, type) {
   console.log(`Queued ${namespace}`);
-  if ((type & 0b10) > 0) {
+
+  if (type & SCRIPT) {
     console.log("Has script");
-    let script_url = browser.runtime.getURL(`web-accessible/furaffinity.net/plugins/${namespace}/index.js`);
-    queuedScripts.push(script_url);
+    const scriptUrl = browser.runtime.getURL(`web-accessible/furaffinity.net/plugins/${namespace}/index.js`);
+    queuedScripts.push(scriptUrl);
   }
-  if ((type & 0b01) > 0) {
+
+  if (type & STYLE) {
     console.log("Has style");
-    let styles_url = browser.runtime.getURL(`web-accessible/furaffinity.net/plugins/${namespace}/style.css`);
-    queuedStylesheets.push(styles_url);
+    const styleUrl = browser.runtime.getURL(`web-accessible/furaffinity.net/plugins/${namespace}/style.css`);
+    queuedStylesheets.push(styleUrl);
   }
 }
 
-queuePlugin("mergeMobileBars", 1);
-queuePlugin("mobileFixMessagesButtons", 1);
-queuePlugin("noBBCodeColor", 1);
-queuePlugin("noMoreNews", 1);
-queuePlugin("removeCookiePopup", 1);
-queuePlugin("removeFooterLinks", 1);
-queuePlugin("removeSiteBanner", 1);
-queuePlugin("removeTopbarSupport", 1);
-queuePlugin("removeTopbarTransactions", 1);
+// Plugin declarations
+[
+  ["mergeMobileBars", STYLE],
+  ["mobileFixMessagesButtons", STYLE],
+  ["noBBCodeColor", STYLE],
+  ["noMoreNews", STYLE],
+  ["removeCookiePopup", STYLE],
+  ["removeFooterLinks", STYLE],
+  ["removeSiteBanner", STYLE],
+  ["removeTopbarSupport", STYLE],
+  ["removeTopbarTransactions", STYLE],
 
-queuePlugin("modules", 2);
+  ["modules", SCRIPT],
+  ["tabStatus", SCRIPT],
+  ["liveStatus", SCRIPT],
+  ["unwatchDATM", SCRIPT],
+  ["systemMessageOverlay", SCRIPT],
+  ["nukeAllMessages", SCRIPT],
 
-queuePlugin("tabStatus", 2);
-queuePlugin("liveStatus", 2);
+  ["noGalleryPreview", STYLE | SCRIPT],
+  ["showMeTheTags", STYLE | SCRIPT]
+].forEach(([name, type]) => queuePlugin(name, type));
 
-queuePlugin("unwatchDATM", 2);
-queuePlugin("systemMessageOverlay", 2);
-
-queuePlugin("nukeAllMessages", 2);
-queuePlugin("noGalleryPreview", 3);
-queuePlugin("showMeTheTags", 3);
-
-// Style functions
-
-function createStyleHolder(element) {
-  let container = document.createElement("div");
+// Style injection
+function createStyleHolder(root) {
+  const container = document.createElement("div");
   container.id = "fatweaks-style-holder";
-  element.appendChild(container);
+  root.appendChild(container);
   return container;
 }
 
+//**
+// function injectStyle(src, parent = document.head) {
+//   const link = document.createElement("link");
+//   link.href = src;
+//   link.rel = "preload stylesheet"; // Note: this is invalid, updated function below
+//   link.setAttribute("blocking", "render");
+//   parent.appendChild(link);
+// }
+//*/
+
 function injectStyle(src, parent = document.head) {
-  const link = document.createElement("link");
-  link.href = src;
-  link.rel = "preload stylesheet";
-  link.setAttribute('blocking', 'render');
-  parent.appendChild(link);
+  const supportsPreload = document.createElement("link").relList.supports?.("preload");
+
+  if (supportsPreload) {
+    const link = document.createElement("link");
+    link.rel = "preload";
+    link.href = src;
+    link.as = "style";
+    link.setAttribute("blocking", "render");
+
+    const swapRel = () => {
+      link.rel = "stylesheet";
+      link.removeAttribute("as");
+    };
+
+    link.onload = swapRel;
+    link.onerror = swapRel;
+
+    parent.appendChild(link);
+  } else {
+    const fallback = document.createElement("link");
+    fallback.rel = "stylesheet";
+    fallback.href = src;
+    fallback.setAttribute("blocking", "render");
+    parent.appendChild(fallback);
+  }
 }
 
 async function onHeadLoaded() {
   styleHolder = createStyleHolder(document.documentElement);
-  queuedStylesheets.forEach(x => injectStyle(x, styleHolder));
+  queuedStylesheets.forEach(src => injectStyle(src, styleHolder));
 }
 
 onHeadLoaded();
 
-// Script functions
-
-function createScriptHolder(element) {
-  let container = document.createElement("div");
+// Script injection
+function createScriptHolder(root) {
+  const container = document.createElement("div");
   container.id = "fatweaks-script-holder";
-  element.appendChild(container);
+  root.appendChild(container);
   return container;
 }
+
 function injectScript(src, parent = document.body) {
   const script = document.createElement("script");
   script.src = src;
@@ -81,9 +115,10 @@ function injectScript(src, parent = document.body) {
   script.defer = true;
   parent.appendChild(script);
 }
+
 async function onPageLoaded() {
   scriptHolder = createScriptHolder(document.body);
-  queuedScripts.forEach(x => injectScript(x, scriptHolder));
+  queuedScripts.forEach(src => injectScript(src, scriptHolder));
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/scripts/furaffinity.net/loader.js
+++ b/scripts/furaffinity.net/loader.js
@@ -26,6 +26,7 @@ function queuePlugins(plugins) {
 
 // Plugin declarations
 queuePlugins([
+  ["fixOverflowingDropdowns", STYLE],
   ["mergeMobileBars", STYLE],
   ["mobileFixMessagesButtons", STYLE],
   ["noBBCodeColor", STYLE],
@@ -37,16 +38,20 @@ queuePlugins([
   ["removeTopbarTransactions", STYLE],
 
   ["modules", SCRIPT],
+  ["settings", SCRIPT],
+  ["allToggleablePlugins", SCRIPT],
 
   ["tabStatus", SCRIPT],
   ["liveStatus", SCRIPT],
 
-  ["unwatchDATM", SCRIPT],
-  ["systemMessageOverlay", SCRIPT],
-
   ["nukeAllMessages", SCRIPT],
   ["noGalleryPreview", STYLE | SCRIPT],
   ["showMeTheTags", STYLE | SCRIPT]
+
+  ["unwatchDATM", SCRIPT],
+  ["systemMessageOverlay", SCRIPT],
+
+  ["faSettingsPage", SCRIPT],
 ]);
 
 // Style injection


### PR DESCRIPTION
[ + ] Added constants `STYLE` and `SCRIPT` for readability
[ ~ ] Moved plugin declarations into an array for easier editing and iteration
[ ~ ] Replaced repeated `queuePlugin` calls with a loop
[ ~ ] Renamed variables
[ ~ ] Standardized `let` / `const` usage and formatting
[ + ] Improved style injection with updated preload support + fallback
[ = ] Behavior unchanged