### PR TITLE
Fixed plugin load order causing execution errors

### DIFF
--- a/scripts/furaffinity.net/loader.js
+++ b/scripts/furaffinity.net/loader.js
@@ -145,4 +145,6 @@ async function onPageLoaded() {
 
 document.addEventListener("DOMContentLoaded", () => {
   onPageLoaded();
+  styleHolder.parentNode.appendChild(styleHolder);
+  scriptHolder.parentNode.appendChild(scriptHolder);
 });


### PR DESCRIPTION
[ ~ ] Refactored script injection to make sure scripts load in order
[ ~ ] Moved all script / style injection into DOMContentLoaded to prevent early execution
[ ~ ] Fixed "__fatweaks is not defined" and redeclaration errors with sequential loading
[ = ] Behavior unchanged once plugins load properly