### PR TITLE
Add "I don't care if you're an admin! You're fucking up my schema!"

### DIFF
--- a/scripts/furaffinity.net/loader.js
+++ b/scripts/furaffinity.net/loader.js
@@ -44,6 +44,7 @@ function queuePlugins(plugins) {
 queuePlugins([
   // Styles are here to be loaded as fast as possible
   ["fixOverflowingDropdowns", STYLE | DEFAULT_PLUGIN],
+  ["iDontCareIfYoureAnAdminYoureFuckingUpMySchema", STYLE],
   ["mergeMobileBars", STYLE],
   ["mobileFixMessagesButtons", STYLE],
   ["noBBCodeColor", STYLE],

--- a/web-accessible/furaffinity.net/plugins/allToggleablePlugins/index.js
+++ b/web-accessible/furaffinity.net/plugins/allToggleablePlugins/index.js
@@ -38,6 +38,14 @@ mySettings.boolean({
 });
 
 mySettings.boolean({
+  name: "\"I don't care if you're an admin! You're fucking up my schema!\"",
+  shortDescription: "Removes the blue tint from admin comments.",
+  authors: ["MeowcaTheoRange"],
+  id: "iDontCareIfYoureAnAdminYoureFuckingUpMySchema",
+  defaultValue: false
+});
+
+mySettings.boolean({
   name: "Live Status",
   shortDescription: "Updates the top-corner notification status every so often",
   authors: ["MeowcaTheoRange"],

--- a/web-accessible/furaffinity.net/plugins/iDontCareIfYoureAnAdminYoureFuckingUpMySchema/style.css
+++ b/web-accessible/furaffinity.net/plugins/iDontCareIfYoureAnAdminYoureFuckingUpMySchema/style.css
@@ -1,0 +1,3 @@
+.comment_container.admin-comment comment-container {
+  background: none;
+}


### PR DESCRIPTION
Plugin to remove that damn blue tint from admin comments. Or something.